### PR TITLE
Fix unmap size bug

### DIFF
--- a/LoongArch/util.c
+++ b/LoongArch/util.c
@@ -160,7 +160,12 @@ void *vtpa(unsigned long long vaddr,int fd)
 int releaseMem(void *p)
 {
     int status ;
-    status = munmap(p-memoffset, 1);
+    /*
+     * munmap length should match the size used in mmap. The previous
+     * implementation only unmapped a single byte which would leak the
+     * rest of the mapping. Unmap the full 64KB region instead.
+     */
+    status = munmap(p - memoffset, 0x10000);
     if(status == -1){
         printf("----------  Release mem Map Error !!! ------\n");
     }


### PR DESCRIPTION
## Summary
- fix `releaseMem()` to unmap the full 64K region

## Testing
- `make -C LoongArch`

------
https://chatgpt.com/codex/tasks/task_e_68406baa8e28833196675b8afcb85ae5