### PR TITLE
Add codec script for base64 encode and decode

### DIFF
--- a/script/codec.sh
+++ b/script/codec.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 encode <input> <output> | decode <input> <output>" >&2
+    exit 1
+}
+
+if [ "$#" -ne 3 ]; then
+    usage
+fi
+
+if ! command -v base64 >/dev/null 2>&1; then
+    echo "Error: required command 'base64' not found" >&2
+    exit 1
+fi
+
+mode="$1"
+input="$2"
+output="$3"
+
+case "$mode" in
+    encode)
+        base64 "$input" > "$output"
+        ;;
+    decode)
+        base64 -d "$input" > "$output"
+        ;;
+    *)
+        usage
+        ;;
+esac


### PR DESCRIPTION
## Summary
- add script/codec.sh to encode/decode files using base64
- check for required base64 command and provide usage info

## Testing
- `./script/codec.sh encode plaintext.txt cipher.txt`
- `./script/codec.sh decode cipher.txt recovered.txt`
- `diff -q plaintext.txt recovered.txt`


------
https://chatgpt.com/codex/tasks/task_e_6895f059500c8331b7df014e3b5cd89b