### PR TITLE
fix(Makefile): Add -std=gnu11 flag to fix build errors

### DIFF
--- a/LoongArch/Makefile
+++ b/LoongArch/Makefile
@@ -13,9 +13,9 @@ GIT_COMMIT_ID := $(shell git rev-parse HEAD)
 
 ARCH := $(shell uname -m)
 ifeq ($(ARCH),loongarch64)
-CFLAGS = -DPLATFORM_LA64
+CFLAGS = -DPLATFORM_LA64 -std=gnu11
 else ifeq ($(ARCH),mips64)
-CFLAGS = -DPLATFORM_MIPS64
+CFLAGS = -DPLATFORM_MIPS64 -std=gnu11
 else
     $(warning Unsupported architecture: $(ARCH))
 endif


### PR DESCRIPTION
指定编译器使用的C标准，在新版GCC中直接构建会报错

```shell
gcc -DPLATFORM_LA64  -DGIT_COMMIT_ID="\"\"" -c util.c -o util.o
util.c:15:13: error: ‘bool’ cannot be defined via ‘typedef’
   15 | typedef int bool;
      |             ^~~~
util.c:15:13: note: ‘bool’ is a keyword with ‘-std=c23’ onwards
util.c:15:1: warning: useless type name in empty declaration
   15 | typedef int bool;
      | ^~~~~~~
make: *** [Makefile:31：util.o] 错误 1
```