### PR TITLE
Makefile: Make -static optional, depending on system support

### DIFF
--- a/LoongArch/Makefile
+++ b/LoongArch/Makefile
@@ -21,10 +21,17 @@ else
 endif
 CFLAGS += -DGIT_COMMIT_ID="\"$(GIT_COMMIT_ID)\""
 
+LIBC_STATIC = $(shell echo "int main(){}" | $(COMPILE_PATH) -x c - --static -o /dev/null > /dev/null 2>&1 || echo "1")
+ifeq ($(LIBC_STATIC),)
+	LD_STATIC := -static
+else
+	LD_STATIC :=
+endif
+
 all: OsTools
 ##.PHONY all SEnd
 OsTools: $(OBJS)
-	$(COMPILE_PATH) -static $^ -o $@
+	$(COMPILE_PATH) $(LD_STATIC) $^ -o $@
 	chmod 777 $@
 
 %.o: %.c

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ flowchart TB
 
 ### 依赖
 
-- 编译依赖：GNU Make、GCC、git
+- 编译依赖：GNU Make、GCC、git（可选）、glibc-static（可选）
 - 脚本依赖（可选）：numpy、pandas、matplotlib、requests、beautifulsoup4
 
 ### 编译与安装


### PR DESCRIPTION
Some systems don't install static libc libraries by default. So make -static optional.